### PR TITLE
Fix compliance report query by removing unnecessary reportKey parameter

### DIFF
--- a/src/deepsource.ts
+++ b/src/deepsource.ts
@@ -2184,7 +2184,7 @@ export class DeepSourceClient {
       // Only use template literal for the dynamic field name
       const fieldName = DeepSourceClient.getReportField(reportType);
       const reportQuery =
-        'query($login: String!, $name: String!, $provider: VCSProvider!, $reportKey: ReportKey!) {' +
+        'query($login: String!, $name: String!, $provider: VCSProvider!) {' +
         '  repository(login: $login, name: $name, vcsProvider: $provider) {' +
         '    name' +
         '    id' +
@@ -2221,7 +2221,6 @@ export class DeepSourceClient {
           login: project.repository.login,
           name: project.name,
           provider: project.repository.provider,
-          reportKey: reportType,
         },
       });
 


### PR DESCRIPTION
## Summary
- Remove the `reportKey` parameter from the compliance report GraphQL query since it is not used in the schema
- Fix issue in the DeepSource client that was causing compliance report requests to fail

## Test plan
- All existing test suites pass
- Verified the fix resolves the issue with retrieving compliance reports

🤖 Generated with [Claude Code](https://claude.ai/code)