### PR TITLE
refactor: remove 'deepsource_' prefix from tool names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,15 +66,15 @@ The codebase is structured around two main components:
    - Sets up the Model Context Protocol server
    - Registers and implements tool handlers for DeepSource API integration
    - Provides nine main tools for AI assistants: 
-     - `deepsource_projects` - List all available projects
-     - `deepsource_project_issues` - Get issues with filtering and pagination
-     - `deepsource_project_runs` - List analysis runs with filtering and pagination
-     - `deepsource_run` - Get details for a specific run
-     - `deepsource_dependency_vulnerabilities` - Get dependency vulnerabilities with pagination
-     - `deepsource_quality_metrics` - Get quality metrics with optional filtering
-     - `deepsource_update_metric_threshold` - Update metric thresholds
-     - `deepsource_update_metric_setting` - Update metric settings for reporting and enforcement
-     - `deepsource_compliance_report` - Get security compliance reports (OWASP, SANS, MISRA-C)
+     - `projects` - List all available projects
+     - `project_issues` - Get issues with filtering and pagination
+     - `project_runs` - List analysis runs with filtering and pagination
+     - `run` - Get details for a specific run
+     - `dependency_vulnerabilities` - Get dependency vulnerabilities with pagination
+     - `quality_metrics` - Get quality metrics with optional filtering
+     - `update_metric_threshold` - Update metric thresholds
+     - `update_metric_setting` - Update metric settings for reporting and enforcement
+     - `compliance_report` - Get security compliance reports (OWASP, SANS, MISRA-C)
 
 2. **DeepSource Client (src/deepsource.ts)**:
    - Implements communication with DeepSource's GraphQL API

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once connected, your AI assistant can use DeepSource data with queries like:
 What issues are in the JavaScript files of my project?
 ```
 
-This would use the `deepsource_project_issues` tool with filters:
+This would use the `project_issues` tool with filters:
 ```
 {
   "projectKey": "your-project-key",
@@ -62,7 +62,7 @@ To filter analysis runs:
 Show me the most recent Python analysis runs
 ```
 
-This would use the `deepsource_project_runs` tool with filters:
+This would use the `project_runs` tool with filters:
 ```
 {
   "projectKey": "your-project-key",
@@ -76,7 +76,7 @@ For code quality metrics:
 What's my code coverage percentage? Is it meeting our thresholds?
 ```
 
-This would use the `deepsource_quality_metrics` tool:
+This would use the `quality_metrics` tool:
 ```
 {
   "projectKey": "your-project-key",
@@ -89,7 +89,7 @@ For security compliance reports:
 Are we compliant with OWASP Top 10 security standards?
 ```
 
-This would use the `deepsource_compliance_report` tool:
+This would use the `compliance_report` tool:
 ```
 {
   "projectKey": "your-project-key",
@@ -102,7 +102,7 @@ For setting thresholds:
 Update our line coverage threshold to 80%
 ```
 
-This would use the `deepsource_update_metric_threshold` tool:
+This would use the `update_metric_threshold` tool:
 ```
 {
   "projectKey": "your-project-key",
@@ -158,11 +158,11 @@ This would use the `deepsource_update_metric_threshold` tool:
 
 The DeepSource MCP Server provides the following tools:
 
-1. `deepsource_projects`: List all available DeepSource projects
+1. `projects`: List all available DeepSource projects
    * Parameters:
      * No required parameters
 
-2. `deepsource_project_issues`: Get issues from a DeepSource project with filtering
+2. `project_issues`: Get issues from a DeepSource project with filtering
    * Parameters:
      * `projectKey` (required) - The unique identifier for the DeepSource project
      * Pagination parameters:
@@ -176,7 +176,7 @@ The DeepSource MCP Server provides the following tools:
        * `analyzerIn` (optional) - Filter issues by specific analyzers (e.g., ["python", "javascript"])
        * `tags` (optional) - Filter issues by tags
 
-3. `deepsource_project_runs`: List analysis runs for a DeepSource project with filtering
+3. `project_runs`: List analysis runs for a DeepSource project with filtering
    * Parameters:
      * `projectKey` (required) - The unique identifier for the DeepSource project
      * Pagination parameters:
@@ -188,11 +188,11 @@ The DeepSource MCP Server provides the following tools:
      * Filtering parameters:
        * `analyzerIn` (optional) - Filter runs by specific analyzers (e.g., ["python", "javascript"])
 
-4. `deepsource_run`: Get a specific analysis run by its runUid or commitOid
+4. `run`: Get a specific analysis run by its runUid or commitOid
    * Parameters:
      * `runIdentifier` (required) - The runUid (UUID) or commitOid (commit hash) to identify the run
 
-5. `deepsource_dependency_vulnerabilities`: Get dependency vulnerabilities from a DeepSource project
+5. `dependency_vulnerabilities`: Get dependency vulnerabilities from a DeepSource project
    * Parameters:
      * `projectKey` (required) - The unique identifier for the DeepSource project
      * Pagination parameters:
@@ -202,7 +202,7 @@ The DeepSource MCP Server provides the following tools:
        * `before` (optional) - Cursor for backward pagination
        * `last` (optional) - Number of items to return before the 'before' cursor (default: 10)
 
-6. `deepsource_quality_metrics`: Get quality metrics from a DeepSource project with filtering
+6. `quality_metrics`: Get quality metrics from a DeepSource project with filtering
    * Parameters:
      * `projectKey` (required) - The unique identifier for the DeepSource project
      * `shortcodeIn` (optional) - Filter metrics by specific shortcodes (e.g., ["LCV", "BCV"])
@@ -213,7 +213,7 @@ The DeepSource MCP Server provides the following tools:
      * Duplicate Code Percentage (DDP)
      * Each metric includes current values, thresholds, and pass/fail status
 
-7. `deepsource_update_metric_threshold`: Update the threshold for a specific quality metric
+7. `update_metric_threshold`: Update the threshold for a specific quality metric
    * Parameters:
      * `projectKey` (required) - The unique identifier for the DeepSource project
      * `repositoryId` (required) - The GraphQL repository ID
@@ -222,7 +222,7 @@ The DeepSource MCP Server provides the following tools:
      * `thresholdValue` (optional) - The new threshold value, or null to remove the threshold
    * Example: Set 80% line coverage threshold: metricShortcode="LCV", metricKey="AGGREGATE", thresholdValue=80
 
-8. `deepsource_update_metric_setting`: Update the settings for a quality metric
+8. `update_metric_setting`: Update the settings for a quality metric
    * Parameters:
      * `projectKey` (required) - The unique identifier for the DeepSource project
      * `repositoryId` (required) - The GraphQL repository ID
@@ -230,7 +230,7 @@ The DeepSource MCP Server provides the following tools:
      * `isReported` (required) - Whether the metric should be reported
      * `isThresholdEnforced` (required) - Whether the threshold should be enforced (can fail checks)
 
-9. `deepsource_compliance_report`: Get security compliance reports from a DeepSource project
+9. `compliance_report`: Get security compliance reports from a DeepSource project
    * Parameters:
      * `projectKey` (required) - The unique identifier for the DeepSource project
      * `reportType` (required) - The type of compliance report to fetch ([OWASP Top 10](https://owasp.org/www-project-top-ten/), [SANS Top 25](https://cwe.mitre.org/top25/), or [MISRA-C](https://www.misra.org.uk/))

--- a/src/__tests__/index-quality-metrics.test.ts
+++ b/src/__tests__/index-quality-metrics.test.ts
@@ -198,9 +198,7 @@ describe('DeepSource MCP Quality Metrics Handlers', () => {
 
       // Verify usage examples are included
       expect(parsedResponse.usage_examples).toBeDefined();
-      expect(parsedResponse.usage_examples.updating_threshold).toContain(
-        'deepsource_update_metric_threshold'
-      );
+      expect(parsedResponse.usage_examples.updating_threshold).toContain('update_metric_threshold');
     });
 
     it('should handle API errors gracefully', async () => {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -80,7 +80,7 @@ describe('MCP server implementation', () => {
     });
   });
 
-  describe('deepsource_projects tool', () => {
+  describe('projects tool', () => {
     it('returns formatted projects', async () => {
       // Define mock data with proper DeepSourceProject structure
       const mockProjects: DeepSourceProject[] = [
@@ -155,7 +155,7 @@ describe('MCP server implementation', () => {
     });
   });
 
-  describe('deepsource_project_issues tool', () => {
+  describe('project_issues tool', () => {
     it('returns formatted issues with all parameters', async () => {
       // Define mock data with proper DeepSourceIssue structure
       const mockIssues: PaginatedResponse<DeepSourceIssue> = {
@@ -384,7 +384,7 @@ describe('MCP server implementation', () => {
     });
   });
 
-  describe('deepsource_project_runs tool', () => {
+  describe('project_runs tool', () => {
     it('returns formatted runs with all parameters', async () => {
       // Define mock data for runs response
       const mockRuns = {
@@ -572,7 +572,7 @@ describe('MCP server implementation', () => {
     });
   });
 
-  describe('deepsource_run tool', () => {
+  describe('run tool', () => {
     it('returns formatted run details', async () => {
       // Define mock data
       const mockRun = {
@@ -678,7 +678,7 @@ describe('MCP server implementation', () => {
     });
   });
 
-  describe('deepsource_dependency_vulnerabilities tool', () => {
+  describe('dependency_vulnerabilities tool', () => {
     // Save original method
     const originalGetDependencyVulnerabilities =
       DeepSourceClient.prototype.getDependencyVulnerabilities;

--- a/src/index.ts
+++ b/src/index.ts
@@ -658,10 +658,9 @@ export async function handleDeepsourceQualityMetrics({
             usage_examples: {
               filtering:
                 'To filter metrics by type, use the shortcodeIn parameter with specific metric codes (e.g., ["LCV", "BCV"])',
-              updating_threshold:
-                'To update a threshold, use the deepsource_update_metric_threshold tool',
+              updating_threshold: 'To update a threshold, use the update_metric_threshold tool',
               updating_settings:
-                'To update metric settings (e.g., enable reporting or threshold enforcement), use the deepsource_update_metric_setting tool',
+                'To update metric settings (e.g., enable reporting or threshold enforcement), use the update_metric_setting tool',
             },
           },
           null,
@@ -715,7 +714,7 @@ export async function handleDeepsourceUpdateMetricThreshold({
               ? `Successfully ${thresholdValue !== null && thresholdValue !== undefined ? 'updated' : 'removed'} threshold for ${metricShortcode} (${metricKey})`
               : `Failed to update threshold for ${metricShortcode} (${metricKey})`,
             next_steps: result.ok
-              ? ['Use deepsource_quality_metrics to view the updated metrics']
+              ? ['Use quality_metrics to view the updated metrics']
               : ['Check if you have sufficient permissions', 'Verify the repository ID is correct'],
           },
           null,
@@ -771,7 +770,7 @@ export async function handleDeepsourceUpdateMetricSetting({
               ? `Successfully updated settings for ${metricShortcode}`
               : `Failed to update settings for ${metricShortcode}`,
             next_steps: result.ok
-              ? ['Use deepsource_quality_metrics to view the updated metrics']
+              ? ['Use quality_metrics to view the updated metrics']
               : ['Check if you have sufficient permissions', 'Verify the repository ID is correct'],
           },
           null,
@@ -1001,7 +1000,7 @@ export async function handleDeepsourceComplianceReport({
                 report.status === ReportStatus.FAILING
                   ? [
                       'Fix critical security issues first',
-                      'Use deepsource_project_issues to view specific issues',
+                      'Use project_issues to view specific issues',
                       'Implement security best practices for your codebase',
                     ]
                   : ['Continue monitoring security compliance', 'Run regular security scans'],
@@ -1026,13 +1025,13 @@ export async function handleDeepsourceComplianceReport({
 
 // Register the tools with the handlers
 mcpServer.tool(
-  'deepsource_projects',
+  'projects',
   'List all available DeepSource projects. Returns a list of project objects with "key" and "name" properties.',
   handleDeepsourceProjects
 );
 
 mcpServer.tool(
-  'deepsource_project_issues',
+  'project_issues',
   `Get issues from a DeepSource project with support for Relay-style cursor-based pagination and filtering.
 For forward pagination, use \`first\` (defaults to 10) with optional \`after\` cursor.
 For backward pagination, use \`last\` (defaults to 10) with optional \`before\` cursor.
@@ -1067,7 +1066,7 @@ Filtering options:
 );
 
 mcpServer.tool(
-  'deepsource_project_runs',
+  'project_runs',
   `List analysis runs for a DeepSource project with support for Relay-style cursor-based pagination and filtering.
 For forward pagination, use \`first\` (defaults to 10) with optional \`after\` cursor.
 For backward pagination, use \`last\` (defaults to 10) with optional \`before\` cursor.
@@ -1098,7 +1097,7 @@ Filtering options:
 );
 
 mcpServer.tool(
-  'deepsource_run',
+  'run',
   'Get a specific analysis run by its runUid (UUID) or commitOid (commit hash).',
   {
     runIdentifier: z
@@ -1109,7 +1108,7 @@ mcpServer.tool(
 );
 
 mcpServer.tool(
-  'deepsource_dependency_vulnerabilities',
+  'dependency_vulnerabilities',
   `Get dependency vulnerabilities from a DeepSource project with support for Relay-style cursor-based pagination.
 For forward pagination, use \`first\` (defaults to 10) with optional \`after\` cursor.
 For backward pagination, use \`last\` (defaults to 10) with optional \`before\` cursor.
@@ -1153,7 +1152,7 @@ The response provides detailed information about each vulnerability, including:
 
 // Register quality metrics tools
 mcpServer.tool(
-  'deepsource_quality_metrics',
+  'quality_metrics',
   `Get quality metrics from a DeepSource project with optional filtering by metric type.
   
   Metrics include code coverage, duplicate code percentage, and more, along with their:
@@ -1175,7 +1174,7 @@ mcpServer.tool(
 );
 
 mcpServer.tool(
-  'deepsource_update_metric_threshold',
+  'update_metric_threshold',
   `Update the threshold for a specific quality metric in a DeepSource project.
   
   This allows setting or removing threshold values that determine if a metric passes or fails.
@@ -1188,7 +1187,7 @@ mcpServer.tool(
     projectKey: z.string().describe('The unique identifier for the DeepSource project'),
     repositoryId: z
       .string()
-      .describe('The GraphQL repository ID (get this from deepsource_quality_metrics response)'),
+      .describe('The GraphQL repository ID (get this from quality_metrics response)'),
     metricShortcode: z
       .nativeEnum(MetricShortcode)
       .describe('The shortcode of the metric to update'),
@@ -1203,7 +1202,7 @@ mcpServer.tool(
 );
 
 mcpServer.tool(
-  'deepsource_update_metric_setting',
+  'update_metric_setting',
   `Update the settings for a quality metric in a DeepSource project.
   
   This allows configuring how metrics are used in the project:
@@ -1218,7 +1217,7 @@ mcpServer.tool(
     projectKey: z.string().describe('The unique identifier for the DeepSource project'),
     repositoryId: z
       .string()
-      .describe('The GraphQL repository ID (get this from deepsource_quality_metrics response)'),
+      .describe('The GraphQL repository ID (get this from quality_metrics response)'),
     metricShortcode: z
       .nativeEnum(MetricShortcode)
       .describe('The shortcode of the metric to update'),
@@ -1273,7 +1272,7 @@ mcpServer.tool(
 
 // Register compliance report tool
 mcpServer.tool(
-  'deepsource_compliance_report',
+  'compliance_report',
   `Get security compliance reports from a DeepSource project.
 
   This tool provides access to industry-standard security compliance reports including:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1234,7 +1234,7 @@ mcpServer.tool(
 // Keeping this commented out as a reference for future implementation
 /*
 mcpServer.tool(
-  'deepsource_metric_history',
+  'metric_history',
   `Get historical trend analysis for code quality metrics from a DeepSource project.
 
   This tool provides access to time-series data for specific metrics including:


### PR DESCRIPTION
## Summary
- Simplified tool naming by removing the redundant 'deepsource_' prefix from all tool names
- Improves usability and reduces verbosity for integrations using this MCP server

## Breaking Changes
⚠️ **This is a breaking change** - Any existing integrations will need to update their code to use the new simplified tool names.

### Tool Name Changes
- `deepsource_projects` → `projects`
- `deepsource_project_issues` → `project_issues`
- `deepsource_project_runs` → `project_runs`
- `deepsource_run` → `run`
- `deepsource_dependency_vulnerabilities` → `dependency_vulnerabilities`
- `deepsource_quality_metrics` → `quality_metrics`
- `deepsource_update_metric_threshold` → `update_metric_threshold`
- `deepsource_update_metric_setting` → `update_metric_setting`
- `deepsource_compliance_report` → `compliance_report`

## Changes Made
✅ Updated all tool registrations in `src/index.ts`
✅ Updated all test files to use new tool names
✅ Updated documentation in README.md and CLAUDE.md
✅ Updated internal references to tools within error messages and examples
✅ Fixed all linting issues
✅ All tests passing with 89.54% code coverage

## Test plan
- [x] Run all tests (`pnpm test`)
- [x] Run linter (`pnpm lint`)
- [x] Run type check (`pnpm check-types`)
- [x] Build the project (`pnpm build`)
- [x] Verify no remaining `deepsource_` prefixes in tool names

🤖 Generated with [Claude Code](https://claude.ai/code)