### PR TITLE
fix: add build step before changeset versioning in CI

### DIFF
--- a/.changeset/fix-changeset-build.md
+++ b/.changeset/fix-changeset-build.md
@@ -1,0 +1,9 @@
+---
+'deepsource-mcp-server': patch
+---
+
+fix: add build step before changeset versioning in ci
+
+- Build TypeScript before running changeset version command to ensure custom changelog generator is available
+- Clean build directory before final release build to ensure SBOM reflects exact release artifacts
+- Fixes CI pipeline failure when using custom changelog generator

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # =============================================================================
+      # BUILD FOR CHANGESET
+      # Build TypeScript to ensure custom changelog generator is available
+      # =============================================================================
+
+      - name: Build for changeset
+        # Must build before versioning since custom changelog is TypeScript
+        # The compiled JS file is needed at: ./dist/src/dev/changelog-custom.js
+        run: pnpm build
+
+      # =============================================================================
       # VERSION MANAGEMENT
       # Determines if release needed based on changesets
       # =============================================================================
@@ -139,8 +149,11 @@ jobs:
 
       - name: Build
         # Skip build if no version change (e.g., docs-only commits)
+        # Clean and rebuild to ensure SBOM reflects exact build artifacts
         if: steps.version.outputs.changed == 'true'
-        run: pnpm build
+        run: |
+          pnpm clean  # Remove any previous build artifacts
+          pnpm build  # Fresh build for release
 
       - name: Generate SBOM
         # Software Bill of Materials for supply chain security


### PR DESCRIPTION
## Summary
- Adds a build step before running changeset version command in CI
- Ensures custom changelog generator is available during versioning
- Cleans build directory before final release build for accurate SBOM

## Problem
The CI pipeline was failing when trying to use the custom changelog generator because it wasn't built before the changeset version command ran. The TypeScript file needs to be compiled to JavaScript first.

## Solution
1. Added a build step specifically for changeset before the version management phase
2. Clean and rebuild before final release to ensure SBOM reflects exact artifacts

## Changes Made
- Added "Build for changeset" step before versioning in `.github/workflows/main.yml`
- Modified final build step to clean before building for release

## Test Plan
- [x] Workflow passes all validation checks
- [x] All tests pass
- [ ] CI pipeline runs successfully with custom changelog generator

🤖 Generated with [Claude Code](https://claude.ai/code)